### PR TITLE
Document movement internals and strengthen regression tests

### DIFF
--- a/jest.unit.config.js
+++ b/jest.unit.config.js
@@ -1,0 +1,19 @@
+module.exports = {
+  verbose: true,
+  testEnvironment: 'node',
+  testMatch: ['**/src/__test__/**/*.spec.ts'],
+  testPathIgnorePatterns: [
+    '<rootDir>/src/__test__/spoof.spec.ts'
+  ],
+  modulePathIgnorePatterns: [
+    './lib',
+    './src/test.ts'
+  ],
+  reporters: [
+    'default',
+    'github-actions'
+  ],
+  transform: {
+    '^.+\\.(t|j)sx?$': '@swc/jest'
+  }
+}

--- a/src/__test__/ghost-cursor-navigation.spec.ts
+++ b/src/__test__/ghost-cursor-navigation.spec.ts
@@ -1,0 +1,238 @@
+import type { MovementAlgorithm, MovementMetrics, MovementTrace } from '../spoof'
+import { GhostCursor } from '../spoof'
+import type { TimedVector, Vector } from '../math'
+import { direction, magnitude } from '../math'
+import type { BoundingBox, Page } from 'puppeteer'
+
+interface MockCdpClient {
+  send: jest.Mock<Promise<void>, [string, unknown]>
+}
+
+interface ScriptedSegment {
+  readonly vectors: Array<Vector | TimedVector>
+  readonly width?: number
+}
+
+/** Converts any vector-like structure into a canonical `Vector`. */
+const toVector = (point: Vector | { x: number, y: number }): Vector => ({ x: point.x, y: point.y })
+
+/** Builds a mock CDP client that records each dispatched mouse event. */
+const mockClient = (): MockCdpClient => ({
+  send: jest.fn().mockResolvedValue(undefined)
+})
+
+/** Creates a minimal `Page` mock compatible with the GhostCursor constructor. */
+const mockPage = (client: MockCdpClient = mockClient()): Page => ({
+  _client: () => client,
+  browser: () => ({
+    isConnected: () => true
+  })
+}) as unknown as Page
+
+/**
+ * Lightweight movement algorithm that replays a scripted set of vectors. It is
+ * used to validate GhostCursor behaviour without depending on Bezier math.
+ */
+class ScriptedAlgorithm implements MovementAlgorithm {
+  public readonly name = 'scripted-movement'
+  private readonly segments: ScriptedSegment[]
+  public readonly contexts: Array<Parameters<MovementAlgorithm['generate']>[0]> = []
+
+  /** Queues the scripted segments that will be replayed by the mock algorithm. */
+  public constructor (segments: ScriptedSegment[]) {
+    this.segments = [...segments]
+  }
+
+  /**
+   * Returns the next scripted segment while capturing the invocation context so
+   * tests can verify continuity between cursor moves.
+   */
+  public generate (context: Parameters<MovementAlgorithm['generate']>[0]): MovementTrace<Vector | TimedVector> {
+    const next = this.segments.shift()
+    if (next === undefined) {
+      throw new Error('No scripted movement segment available for test invocation')
+    }
+
+    this.contexts.push(context)
+    const finish = next.vectors[next.vectors.length - 1]
+    const firstVector = next.vectors[0]
+    const metrics: MovementMetrics = {
+      steps: next.vectors.length,
+      distance: magnitude(direction(context.start, toVector(context.end))),
+      width: 'width' in context.end && context.end.width !== 0 ? context.end.width : next.width ?? 0,
+      duration: 'timestamp' in firstVector && 'timestamp' in finish
+        ? (finish).timestamp - (firstVector).timestamp
+        : null
+    }
+
+    return {
+      algorithm: this.name,
+      vectors: next.vectors,
+      metrics
+    }
+  }
+}
+
+describe('GhostCursor complex navigation sequences', () => {
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('streams scripted movement traces through multiple regions of a complex page', async () => {
+    // Arrange: build a three-segment script mirroring a demanding user journey.
+    const segments: ScriptedSegment[] = [
+      {
+        vectors: [
+          { x: 48, y: 48, timestamp: 10 },
+          { x: 180, y: 72, timestamp: 18 },
+          { x: 300, y: 110, timestamp: 32 }
+        ],
+        width: 280
+      },
+      {
+        vectors: [
+          { x: 300, y: 110, timestamp: 40 },
+          { x: 402, y: 156, timestamp: 56 },
+          { x: 512, y: 240, timestamp: 80 }
+        ],
+        width: 140
+      },
+      {
+        vectors: [
+          { x: 512, y: 240, timestamp: 90 },
+          { x: 640, y: 310, timestamp: 102 },
+          { x: 704, y: 420, timestamp: 118 },
+          { x: 752, y: 512, timestamp: 135 }
+        ],
+        width: 96
+      }
+    ]
+
+    // Arrange: instantiate the cursor with deterministic scripted vectors.
+    const algorithm = new ScriptedAlgorithm(segments)
+    const client = mockClient()
+    const page = mockPage(client)
+    const cursor = new GhostCursor(page, {
+      start: { x: 48, y: 48 },
+      movementAlgorithm: algorithm,
+      defaultOptions: {
+        moveTo: { useTimestamps: true, moveDelay: 0, randomizeMoveDelay: false }
+      }
+    })
+
+    // Arrange: identify complex targets reminiscent of a real web application.
+    const navTrigger: BoundingBox = { x: 300, y: 110, width: 280, height: 60 }
+    const submenuTarget: BoundingBox = { x: 512, y: 240, width: 140, height: 48 }
+    const toolbarAction: BoundingBox = { x: 752, y: 512, width: 96, height: 32 }
+
+    // Act: sequentially move through the complex layout.
+    await cursor.moveTo(navTrigger)
+    await cursor.moveTo(submenuTarget)
+    await cursor.moveTo(toolbarAction)
+
+    // Assert: collect all CDP calls emitted during the scripted navigation.
+    const sendCalls = client.send.mock.calls
+    expect(sendCalls).toHaveLength(10)
+
+    // Extract timestamps and coordinates for human-readable verification.
+    const timestamps = sendCalls.map(([_, payload]) => (payload as { timestamp?: number }).timestamp)
+    const coords = sendCalls.map(([_, payload]) => ({ x: (payload as { x: number }).x, y: (payload as { y: number }).y }))
+
+    // Assert: verify timestamp propagation and ordering across the full journey.
+    expect(timestamps.filter((value): value is number => value !== undefined)).toEqual([
+      10, 18, 32,
+      40, 56, 80,
+      90, 102, 118, 135
+    ])
+
+    // Assert: snapshot the entry and exit coordinates to detect regressions.
+    expect(coords.slice(0, 3)).toMatchInlineSnapshot(`
+      [
+        {
+          "x": 48,
+          "y": 48,
+        },
+        {
+          "x": 180,
+          "y": 72,
+        },
+        {
+          "x": 300,
+          "y": 110,
+        },
+      ]
+    `)
+
+    expect(coords.slice(-3)).toMatchInlineSnapshot(`
+      [
+        {
+          "x": 640,
+          "y": 310,
+        },
+        {
+          "x": 704,
+          "y": 420,
+        },
+        {
+          "x": 752,
+          "y": 512,
+        },
+      ]
+    `)
+
+    expect(cursor.getLocation()).toEqual({ x: 752, y: 512, timestamp: 135 })
+
+    // Assert: ensure every move started from the previous location.
+    expect(algorithm.contexts).toHaveLength(3)
+    expect(algorithm.contexts[0].start).toEqual({ x: 48, y: 48 })
+    expect(algorithm.contexts[1].start).toEqual({ x: 300, y: 110, timestamp: 32 })
+    expect(algorithm.contexts[2].start).toEqual({ x: 512, y: 240, timestamp: 80 })
+  })
+
+  it('updates the cursor location correctly when timestamps are omitted', async () => {
+    // Arrange: set up a scripted path without timestamps to mimic a light-weight algorithm.
+    const segments: ScriptedSegment[] = [
+      {
+        vectors: [
+          { x: 10, y: 10 },
+          { x: 20, y: 25 },
+          { x: 30, y: 30 }
+        ]
+      },
+      {
+        vectors: [
+          { x: 30, y: 30 },
+          { x: 35, y: 40 },
+          { x: 40, y: 50 }
+        ]
+      }
+    ]
+
+    // Arrange: initialise the cursor with deterministic scripted output.
+    const algorithm = new ScriptedAlgorithm(segments)
+    const client = mockClient()
+    const page = mockPage(client)
+    const cursor = new GhostCursor(page, {
+      start: { x: 10, y: 10 },
+      movementAlgorithm: algorithm,
+      defaultOptions: {
+        moveTo: { useTimestamps: false, moveDelay: 0, randomizeMoveDelay: false }
+      }
+    })
+
+    const firstTarget: BoundingBox = { x: 30, y: 30, width: 40, height: 20 }
+    const secondTarget: BoundingBox = { x: 40, y: 50, width: 50, height: 30 }
+
+    // Act: perform two consecutive moves using the non-timestamped trace.
+    await cursor.moveTo(firstTarget)
+    await cursor.moveTo(secondTarget)
+
+    // Assert: ensure the cursor location reflects the final coordinates without timestamps.
+    expect(cursor.getLocation()).toEqual({ x: 40, y: 50 })
+    expect(client.send).toHaveBeenCalledTimes(6)
+
+    // Assert: confirm the algorithm received sequential start contexts.
+    expect(algorithm.contexts[0].start).toEqual({ x: 10, y: 10 })
+    expect(algorithm.contexts[1].start).toEqual({ x: 30, y: 30 })
+  })
+})

--- a/src/__test__/movement-engine.spec.ts
+++ b/src/__test__/movement-engine.spec.ts
@@ -1,0 +1,307 @@
+import type { TimedVector, Vector } from '../math'
+import { MovementEngine, BezierMovementAlgorithm, type MovementAlgorithm } from '../spoof'
+import { direction, magnitude } from '../math'
+
+type RandomSpy = jest.SpyInstance<number, []>
+
+/**
+ * Replaces `Math.random` with a deterministic generator so the Bezier
+ * algorithm produces predictable paths for assertions.
+ */
+const mockMathRandomSequence = (values: number[]): RandomSpy => {
+  let index = 0
+  return jest.spyOn(Math, 'random').mockImplementation(() => {
+    if (index >= values.length) {
+      throw new Error(`Math.random called more times than expected (provided ${values.length} values).`)
+    }
+    const value = values[index]
+    index += 1
+    return value
+  })
+}
+
+/** Converts any vector-like input into a canonical `Vector` instance. */
+const toVector = (point: Vector | { x: number, y: number }): Vector => ({ x: point.x, y: point.y })
+
+describe('MovementEngine (BezierMovementAlgorithm)', () => {
+  const start: Vector = { x: 12, y: 24 }
+  const end: Vector = { x: 160, y: 96 }
+  let engine: MovementEngine
+
+  beforeEach(() => {
+    engine = new MovementEngine(new BezierMovementAlgorithm())
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+    jest.useRealTimers()
+  })
+
+  it('produces deterministic bezier paths with stable metrics when randomness is mocked', () => {
+    // Arrange: force the algorithm to use known control points and speeds.
+    const randomMock = mockMathRandomSequence([0.1, 0.2, 0.3, 0.4, 0.5])
+
+    // Act: generate a trace with explicit spread and speed overrides.
+    const trace = engine.generate(start, end, { moveSpeed: 90, spreadOverride: 30 })
+
+    // Assert: the algorithm metadata and boundary coordinates are preserved.
+    expect(trace.algorithm).toBe('bezier-default')
+    expect(trace.vectors).toHaveLength(28)
+    expect(trace.vectors[0]).toEqual(start)
+    expect(trace.vectors[trace.vectors.length - 1]).toEqual(end)
+    expect(trace.metrics.steps).toBe(28)
+    expect(trace.metrics.distance).toBeCloseTo(magnitude(direction(start, end)))
+    expect(trace.metrics.duration).toBeNull()
+
+    // Assert: the first few and final vectors remain unchanged over time.
+    expect(trace.vectors.slice(0, 4)).toMatchInlineSnapshot(`
+      [
+        {
+          "x": 12,
+          "y": 24,
+        },
+        {
+          "x": 14.860231713077722,
+          "y": 26.488774266809983,
+        },
+        {
+          "x": 17.751711439008997,
+          "y": 28.959190273054247,
+        },
+        {
+          "x": 20.694885567959737,
+          "y": 31.41509309369166,
+        },
+      ]
+    `)
+
+    expect(trace.vectors.slice(-4)).toMatchInlineSnapshot(`
+      [
+        {
+          "x": 130.65350635726003,
+          "y": 86.44613420405622,
+        },
+        {
+          "x": 139.90689406461584,
+          "y": 89.55555090593734,
+        },
+        {
+          "x": 149.68224314880717,
+          "y": 92.73889114626563,
+        },
+        {
+          "x": 160,
+          "y": 96,
+        },
+      ]
+    `)
+
+    randomMock.mockRestore()
+  })
+
+  it('generates monotonic timestamps and duration metrics when requested', () => {
+    // Arrange: deterministically control randomness and the system clock.
+    const randomMock = mockMathRandomSequence([0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7])
+
+    jest.useFakeTimers()
+    jest.setSystemTime(new Date('2023-11-14T22:13:20.000Z'))
+
+    // Act: generate a trace that includes timestamps.
+    const trace = engine.generate(start, end, { spreadOverride: 30, useTimestamps: true })
+    const vectors = trace.vectors as TimedVector[]
+
+    // Assert: movement metadata describes a timestamped trace.
+    expect(vectors).toHaveLength(52)
+    expect(vectors[0]).toEqual({ x: 12, y: 24, timestamp: 1700000000000 })
+    expect(vectors[vectors.length - 1]).toEqual({ x: 160, y: 96, timestamp: 1700000000592 })
+    expect(trace.metrics.duration).toBe(592)
+
+    // Assert: each timestamp should be monotonically increasing.
+    for (let i = 1; i < vectors.length; i++) {
+      expect(vectors[i].timestamp).toBeGreaterThanOrEqual(vectors[i - 1].timestamp)
+    }
+
+    // Assert: snapshot the start and end of the trace for future regression detection.
+    expect(vectors.slice(0, 3)).toMatchInlineSnapshot(`
+      [
+        {
+          "timestamp": 1700000000000,
+          "x": 12,
+          "y": 24,
+        },
+        {
+          "timestamp": 1700000000007,
+          "x": 13.511596340097405,
+          "y": 25.320108008533815,
+        },
+        {
+          "timestamp": 1700000000014,
+          "x": 15.029253997693658,
+          "y": 26.63456347618175,
+        },
+      ]
+    `)
+
+    expect(vectors.slice(-3)).toMatchInlineSnapshot(`
+      [
+        {
+          "timestamp": 1700000000552,
+          "x": 149.09240762775784,
+          "y": 92.54952064000062,
+        },
+        {
+          "timestamp": 1700000000572,
+          "x": 154.46884326472477,
+          "y": 94.26360837727351,
+        },
+        {
+          "timestamp": 1700000000592,
+          "x": 160,
+          "y": 96,
+        },
+      ]
+    `)
+
+    randomMock.mockRestore()
+  })
+
+  /**
+   * Minimal linear algorithm used to demonstrate pluggable strategy support.
+   */
+  class LinearMovementAlgorithm implements MovementAlgorithm {
+    public readonly name = 'linear-test'
+    public readonly contexts: Array<{ start: Vector, end: Vector }> = []
+
+    /** Returns a trivial two-vector trace for deterministic assertions. */
+    public generate ({ start, end }: Parameters<MovementAlgorithm['generate']>[0]): ReturnType<MovementAlgorithm['generate']> {
+      const finish = toVector(end)
+      this.contexts.push({ start, end: finish })
+      return {
+        algorithm: this.name,
+        vectors: [start, finish],
+        metrics: {
+          steps: 2,
+          distance: magnitude(direction(start, finish)),
+          width: 'width' in end && end.width !== 0 ? end.width : 0,
+          duration: null
+        }
+      }
+    }
+  }
+
+  it('supports pluggable algorithms for experimentation', () => {
+    // Arrange: inject the test algorithm into a new engine instance.
+    const algorithm = new LinearMovementAlgorithm()
+    const linearEngine = new MovementEngine(algorithm)
+    const finish: Vector = { x: 64, y: 144 }
+
+    // Act: generate a simple straight-line trace.
+    const trace = linearEngine.generate(start, finish)
+
+    // Assert: the algorithm context and output were forwarded untouched.
+    expect(trace.algorithm).toBe('linear-test')
+    expect(trace.vectors).toEqual([start, finish])
+    expect(trace.metrics.steps).toBe(2)
+    expect(algorithm.contexts).toHaveLength(1)
+    expect(algorithm.contexts[0]).toEqual({ start, end: finish })
+  })
+
+  it('navigates complex multi-target layouts while preserving continuity and adaptive pacing', () => {
+    // Arrange: craft a complex navigation scenario using deterministic randomness.
+    const randomMock = mockMathRandomSequence([
+      0.05, 0.18, 0.22, 0.37, 0.41,
+      0.52, 0.63, 0.15, 0.29, 0.44,
+      0.58, 0.69, 0.11, 0.24, 0.36
+    ])
+
+    // Define high-level navigation waypoints that mimic a dense web application.
+    const segments: Array<{
+      readonly label: string
+      readonly end: Vector & { width: number, height: number }
+      readonly options: { moveSpeed: number, spreadOverride: number }
+    }> = [
+      {
+        label: 'global navigation to mega menu entry',
+        end: { x: 320, y: 180, width: 220, height: 60 },
+        options: { moveSpeed: 95, spreadOverride: 35 }
+      },
+      {
+        label: 'mega menu to nested panel CTA',
+        end: { x: 640, y: 420, width: 80, height: 32 },
+        options: { moveSpeed: 65, spreadOverride: 18 }
+      },
+      {
+        label: 'panel CTA to floating toolbar action',
+        end: { x: 1180, y: 760, width: 40, height: 28 },
+        options: { moveSpeed: 45, spreadOverride: 12 }
+      }
+    ]
+
+    let current = { x: 96, y: 32 }
+    const stepCounts: number[] = []
+    let totalDistance = 0
+
+    // Act: walk through each segment, ensuring continuity across moves.
+    for (const segment of segments) {
+      const trace = engine.generate(current, segment.end, segment.options)
+      const finish = trace.vectors[trace.vectors.length - 1]
+
+      // Assert: confirm continuity and consistent width metrics for each target.
+      expect(trace.vectors[0]).toEqual(current)
+      expect(finish.x).toBeCloseTo(segment.end.x, 3)
+      expect(finish.y).toBeCloseTo(segment.end.y, 3)
+      expect(trace.metrics.steps).toBeGreaterThan(10)
+      expect(trace.metrics.width).toBe(segment.end.width)
+
+      stepCounts.push(trace.metrics.steps)
+      totalDistance += trace.metrics.distance
+      current = toVector(finish)
+    }
+
+    // Assert: after the final segment we should be positioned at the final target.
+    expect(current.x).toBeCloseTo(segments[segments.length - 1].end.x, 3)
+    expect(current.y).toBeCloseTo(segments[segments.length - 1].end.y, 3)
+
+    // Assert: Fitts' Law heuristics should scale step counts with difficulty.
+    expect(stepCounts[0]).toBeLessThan(stepCounts[1])
+    expect(stepCounts[1]).toBeLessThan(stepCounts[2])
+    expect(totalDistance).toBeGreaterThan(segments[segments.length - 1].end.x)
+
+    randomMock.mockRestore()
+  })
+
+  it('clamps negative intermediate coordinates to zero to prevent off-screen drift', () => {
+    // Arrange: ensure randomness is predictable and the start point begins off-screen.
+    const randomMock = mockMathRandomSequence(Array.from({ length: 64 }, () => 0.5))
+    const offscreenStart: Vector = { x: -50, y: -25 }
+    const nearTarget: Vector = { x: 10, y: 5 }
+
+    // Act: generate a trace moving back into the viewport.
+    const trace = engine.generate(offscreenStart, nearTarget, { spreadOverride: 10 })
+
+    // Assert: every vector should be clamped at or above zero on both axes.
+    for (const vector of trace.vectors) {
+      expect(vector.x).toBeGreaterThanOrEqual(0)
+      expect(vector.y).toBeGreaterThanOrEqual(0)
+    }
+    expect(trace.vectors[0]).toEqual({ x: 0, y: 0 })
+    expect(trace.vectors[trace.vectors.length - 1]).toEqual(nearTarget)
+
+    randomMock.mockRestore()
+  })
+
+  it('produces a degenerate but valid trace when start and end points coincide', () => {
+    // Arrange: create a context with zero distance between start and end.
+    const stationaryPoint: Vector = { x: 256, y: 256 }
+
+    // Act: request a trace for a no-op movement.
+    const trace = engine.generate(stationaryPoint, stationaryPoint, { moveSpeed: 75 })
+
+    // Assert: the trace should contain at least the starting point and never wander.
+    expect(trace.vectors.length).toBeGreaterThanOrEqual(1)
+    expect(trace.vectors[0]).toEqual(stationaryPoint)
+    expect(trace.vectors[trace.vectors.length - 1]).toEqual(stationaryPoint)
+    expect(trace.metrics.distance).toBeCloseTo(0)
+    expect(trace.metrics.steps).toBe(trace.vectors.length)
+  })
+})

--- a/src/movement/bezier-movement.ts
+++ b/src/movement/bezier-movement.ts
@@ -1,0 +1,152 @@
+import { bezierCurve, bezierCurveSpeed, direction, extrapolate, magnitude } from '../math'
+import type { TimedVector, Vector } from '../math'
+import type { MovementAlgorithm, MovementContext, MovementMetrics, MovementOptions, MovementTrace } from './types'
+
+const DEFAULT_WIDTH = 100
+const MIN_STEPS = 25
+
+/**
+ * Estimates the index of difficulty using a simplified Fitts' Law formula.
+ * The result is used to scale the number of points generated for the movement.
+ */
+const fitts = (distance: number, width: number): number => {
+  const a = 0
+  const b = 2
+  const id = Math.log2(distance / width + 1)
+  return a + b * id
+}
+
+/**
+ * Clamps all vectors to positive coordinates and optionally enriches them
+ * with timestamps if the caller requested temporal information.
+ */
+const clampPositive = (
+  vectors: Vector[],
+  options: MovementOptions
+): Array<Vector | TimedVector> => {
+  const clampedVectors = vectors.map((vector) => ({
+    x: Math.max(0, vector.x),
+    y: Math.max(0, vector.y)
+  }))
+
+  return options.useTimestamps === true
+    ? generateTimestamps(clampedVectors, options)
+    : clampedVectors
+}
+
+/**
+ * Adds monotonically increasing timestamps to a set of vectors. The cadence is
+ * derived from the distance traveled along the Bezier curve and an optional
+ * move speed override.
+ */
+const generateTimestamps = (
+  vectors: Vector[],
+  options: MovementOptions
+): TimedVector[] => {
+  const speed = options.moveSpeed ?? (Math.random() * 0.5 + 0.5)
+
+  /**
+   * Approximates the travel time between four consecutive control points by
+   * sampling the Bezier curve and integrating the instantaneous speeds.
+   */
+  const timeToMove = (P0: Vector, P1: Vector, P2: Vector, P3: Vector, samples: number): number => {
+    let total = 0
+    const dt = 1 / samples
+
+    for (let t = 0; t < 1; t += dt) {
+      const v1 = bezierCurveSpeed(t * dt, P0, P1, P2, P3)
+      const v2 = bezierCurveSpeed(t, P0, P1, P2, P3)
+      total += (v1 + v2) * dt / 2
+    }
+
+    return Math.round(total / speed)
+  }
+
+  const timedVectors: TimedVector[] = []
+
+  for (let i = 0; i < vectors.length; i++) {
+    if (i === 0) {
+      timedVectors.push({ ...vectors[i], timestamp: Date.now() })
+    } else {
+      const P0 = vectors[i - 1]
+      const P1 = vectors[i]
+      const P2 = i + 1 < vectors.length ? vectors[i + 1] : extrapolate(P0, P1)
+      const P3 = i + 2 < vectors.length ? vectors[i + 2] : extrapolate(P1, P2)
+      const time = timeToMove(P0, P1, P2, P3, vectors.length)
+
+      timedVectors.push({
+        ...vectors[i],
+        timestamp: timedVectors[i - 1].timestamp + time
+      })
+    }
+  }
+
+  return timedVectors
+}
+
+/**
+ * Computes the total duration in milliseconds for a trace when timestamps are
+ * present. When timestamps are absent the duration is undefined (null).
+ */
+const computeDuration = (vectors: Array<Vector | TimedVector>): number | null => {
+  if (vectors.length === 0) return null
+  const first = vectors[0]
+
+  if (!('timestamp' in first)) return null
+
+  const last = vectors[vectors.length - 1] as TimedVector
+  return last.timestamp - first.timestamp
+}
+
+/**
+ * Normalizes an arbitrary point-like object into a `Vector` shape.
+ */
+const toVector = (point: Vector | { x: number, y: number }): Vector => ({ x: point.x, y: point.y })
+
+/**
+ * Summarizes the generated trace with metrics such as step count, distance and
+ * optional duration to help callers validate the resulting movement profile.
+ */
+const buildMetrics = (
+  start: Vector,
+  finish: Vector,
+  width: number,
+  vectors: Array<Vector | TimedVector>
+): MovementMetrics => ({
+  steps: vectors.length,
+  distance: magnitude(direction(start, finish)),
+  width,
+  duration: computeDuration(vectors)
+})
+
+/**
+ * Default movement algorithm that generates human-like paths using Bezier
+ * curves. The algorithm adapts the number of generated steps based on Fitts'
+ * Law and clamps vectors so they remain within the visible viewport.
+ */
+export class BezierMovementAlgorithm implements MovementAlgorithm {
+  public readonly name = 'bezier-default'
+
+  /**
+   * Generates a Bezier-based movement trace for the requested context.
+   */
+  public generate ({ start, end, options }: MovementContext): MovementTrace<Vector | TimedVector> {
+    const finish = toVector(end)
+    const width = 'width' in end && end.width !== 0 ? end.width : DEFAULT_WIDTH
+    const curve = bezierCurve(start, finish, options.spreadOverride)
+    const length = curve.length() * 0.8
+
+    const speed = options.moveSpeed !== undefined && options.moveSpeed > 0
+      ? (25 / options.moveSpeed)
+      : Math.random()
+    const baseTime = speed * MIN_STEPS
+    const steps = Math.ceil((Math.log2(fitts(length, width) + 1) + baseTime) * 3)
+    const vectors = clampPositive(curve.getLUT(steps) as Vector[], options)
+
+    return {
+      algorithm: this.name,
+      vectors,
+      metrics: buildMetrics(start, finish, width, vectors)
+    }
+  }
+}

--- a/src/movement/movement-engine.ts
+++ b/src/movement/movement-engine.ts
@@ -1,0 +1,46 @@
+import type { MovementAlgorithm, MovementContext, MovementOptions, MovementTrace } from './types'
+import type { TimedVector, Vector } from '../math'
+import type { BoundingBox } from 'puppeteer'
+
+/**
+ * Normalizes optional movement options so algorithms always receive a complete
+ * object and can rely on a deterministic `useTimestamps` flag.
+ */
+const normalizeOptions = (options?: MovementOptions): MovementOptions => ({
+  spreadOverride: options?.spreadOverride,
+  moveSpeed: options?.moveSpeed,
+  useTimestamps: options?.useTimestamps ?? false
+})
+
+/**
+ * Small façade that accepts raw start/end inputs and defers to a pluggable
+ * algorithm to produce a movement trace. The engine ensures a consistent
+ * context object is passed to the algorithm.
+ */
+export class MovementEngine {
+  /**
+   * Builds a new engine for the given movement algorithm.
+   * @param algorithm concrete strategy responsible for generating traces
+   */
+  public constructor (public readonly algorithm: MovementAlgorithm) {}
+
+  /**
+   * Generates a movement trace from the currently configured algorithm.
+   * @param start current cursor location
+   * @param end destination coordinates or element bounding box
+   * @param options optional overrides that tweak how the path is generated
+   */
+  public generate<T extends Vector | TimedVector = Vector | TimedVector>(
+    start: Vector,
+    end: Vector | BoundingBox,
+    options?: MovementOptions
+  ): MovementTrace<T> {
+    const context: MovementContext = {
+      start,
+      end,
+      options: normalizeOptions(options)
+    }
+
+    return this.algorithm.generate(context) as MovementTrace<T>
+  }
+}

--- a/src/movement/types.ts
+++ b/src/movement/types.ts
@@ -1,0 +1,70 @@
+import type { BoundingBox } from 'puppeteer'
+import type { TimedVector, Vector } from '../math'
+
+/**
+ * Configuration flags that movement algorithms may honor when producing a path.
+ * Each option is optional so callers can request fine-grained overrides while
+ * still allowing algorithms to fall back to their default heuristics.
+ */
+export interface MovementOptions {
+  /** How aggressively the generated path may deviate from a straight line. */
+  readonly spreadOverride?: number
+  /** Higher values cause algorithms to complete the movement faster. */
+  readonly moveSpeed?: number
+  /** When true algorithms should attach timestamps to the returned vectors. */
+  readonly useTimestamps?: boolean
+}
+
+/**
+ * The immutable context supplied to a movement algorithm describing the
+ * starting point, the requested end position (or element box) and the
+ * caller-specified options for how the move should be generated.
+ */
+export interface MovementContext {
+  /** Current location of the cursor when the algorithm is invoked. */
+  readonly start: Vector
+  /** Destination vector or bounding box to navigate towards. */
+  readonly end: Vector | BoundingBox
+  /** Per-call option overrides applied during path generation. */
+  readonly options: MovementOptions
+}
+
+/**
+ * Metrics describing the generated path so tests and telemetry can reason
+ * about the movement profile without re-inspecting the raw vectors.
+ */
+export interface MovementMetrics {
+  /** Total number of intermediate vectors in the trace. */
+  readonly steps: number
+  /** Euclidean distance between the starting and ending points. */
+  readonly distance: number
+  /** Effective width of the destination target used for Fitts' Law scaling. */
+  readonly width: number
+  /** Duration in milliseconds when timestamps are present, otherwise null. */
+  readonly duration: number | null
+}
+
+/**
+ * A full description of an algorithm's output containing the generated
+ * vectors and the computed metrics along with an algorithm identifier.
+ */
+export interface MovementTrace<T extends Vector = Vector> {
+  /** Human-readable identifier for the algorithm that produced the trace. */
+  readonly algorithm: string
+  /** Ordered list of cursor coordinates that form the movement path. */
+  readonly vectors: T[]
+  /** Summary information describing the produced path. */
+  readonly metrics: MovementMetrics
+}
+
+/**
+ * Contract implemented by every pluggable movement algorithm. Algorithms must
+ * expose a name for diagnostics and provide a `generate` method that returns
+ * a movement trace given a context.
+ */
+export interface MovementAlgorithm {
+  /** Unique identifier for the algorithm implementation. */
+  readonly name: string
+  /** Produce a trace describing how to move from the start to the end point. */
+  generate: (context: MovementContext) => MovementTrace<Vector | TimedVector>
+}


### PR DESCRIPTION
## Summary
- add JSDoc annotations across movement types, engine, and Bezier helpers to clarify extension points
- expand the MovementEngine unit suite with inline documentation and edge-case coverage for clamping and stationary moves
- document the GhostCursor navigation harness and add regression coverage for timestamp-less scripted algorithms

## Testing
- yarn jest --config jest.unit.config.js

------
https://chatgpt.com/codex/tasks/task_e_68d04bf8842883309282386d2b18b086